### PR TITLE
feat: add clippy lints at cargo manifest level

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,23 +1,35 @@
-on: [pull_request]
-name: benchmark pull requests
-jobs:
-  runBenchmark:
-    name: run benchmark
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: boa-dev/criterion-compare-action@v3
-        with:
-          # cwd: "subDirectory (optional)"
-          # # Optional. Compare only this package
-          # package: "example-package"
-          # # Optional. Compare only this benchmark target
-          # benchName: "example-bench-target"
-          # # Optional. Disables the default features of a crate
-          # defaultFeatures: false
-          # # Optional. Features activated in the benchmark
-          # features: "async,tokio-support"
-          # Needed. The name of the branch to compare with. This default uses the branch which is being pulled against
-          branchName: ${{ github.base_ref }}
-          # Optional. Default is `${{ github.token }}`.
-          token: ${{ secrets.GITHUB_TOKEN }}
+# on: [pull_request]
+# name: benchmark pull requests
+# jobs:
+#   runBenchmark:
+#     name: run benchmark
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v4
+#       - name: Install Valgrind
+#         run: |
+#           sudo apt-get update
+#           sudo apt-get install -y valgrind
+#       - uses: taiki-e/install-action@cargo-binstall
+#       - name: Install gungraun-runner
+#         run: |
+#           version=$(cargo metadata --format-version=1 |\
+#             jq '.packages[] | select(.name == "gungraun").version' |\
+#             tr -d '"'
+#           )
+#           cargo binstall --no-confirm gungraun-runner --version $version
+#       - uses: boa-dev/criterion-compare-action@v3
+#         with:
+#           cwd: "meficore"
+#           # # Optional. Compare only this package
+#           # package: "example-package"
+#           # # Optional. Compare only this benchmark target
+#           benchName: "submesh_analytics"
+#           # # Optional. Disables the default features of a crate
+#           # defaultFeatures: false
+#           # # Optional. Features activated in the benchmark
+#           # features: "async,tokio-support"
+#           # Needed. The name of the branch to compare with. This default uses the branch which is being pulled against
+#           branchName: ${{ github.base_ref }}
+#           # Optional. Default is `${{ github.token }}`.
+#           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,25 +2,25 @@ name: Rust
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   pre-commit:
-      runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
 
-      steps:
+    steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: "3.x"
 
       - name: Install pre-commit
         run: pip install pre-commit
@@ -29,27 +29,37 @@ jobs:
         run: pre-commit run --all-files
 
   build:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
-
-  benchmark:
-
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose
+
+  benchmark:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Valgrind
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y valgrind
+      - uses: taiki-e/install-action@cargo-binstall
+      - name: Install gungraun-runner
+        run: |
+          version=$(cargo metadata --format-version=1 |\
+            jq '.packages[] | select(.name == "gungraun").version' |\
+            tr -d '"'
+          )
+          cargo binstall --no-confirm gungraun-runner --version $version
       - run: cargo bench -- --output-format bencher | tee output.txt
       - uses: benchmark-action/github-action-benchmark@v1
         with:
-          tool: 'cargo'
+          tool: "cargo"
           output-file-path: output.txt
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          alert-threshold: '150%'
+          alert-threshold: "150%"
           fail-on-alert: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,16 @@ repos:
       - id: ruff-check
       # Run the formatter.
       - id: ruff-format
+  - repo: local
+    hooks:
+      - id: cargo-clippy
+        name: Lint Rust extensively
+        types_or: [rust]
+        language: system
+        pass_filenames: false
+        entry: "cargo clippy -- --deny warnings"
+        # NOTE: It's impossible to use `--fix --allow-dirty` below as it
+        # deactivates `--deny warnings` (see [this discussion] for more
+        # information).
+        #
+        # [this discussion]: https://github.com/rust-lang/rust-clippy/discussions/9979

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,23 @@ serde_yaml = "0.9.34"
 smallvec = "1.15.1"
 vtkio = "0.7.0-rc1"
 
+[workspace.lints.clippy]
+# Set a lower priority for certain flags to be overriden below.
+all = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+
+# Override above, with default priority of 0.
+# Above each deactivated lint is the corresponding rationale.
+
+# Checking floats for exact equality is quite obsvious to reason about, and is
+# very frequently used in tests.
+float_cmp = "allow"
+# It's a pain to match expected panic messages exactly, with not much added
+# value.
+should_panic_without_expect = "allow"
+# #[must_use] is visually invasive. Activating it requires more discussion from
+# the dev team.
+must_use_candidate = "allow"
 
 [profile.release]
 opt-level = 3

--- a/meficore/benches/merge_nodes.rs
+++ b/meficore/benches/merge_nodes.rs
@@ -17,7 +17,7 @@ fn merge_nodes(c: &mut Criterion) {
                     mf::crack(m1, cut.view())
                 },
                 |mut cracked| {
-                    std::hint::black_box(mf::merge_nodes(&mut cracked, 1e-12));
+                    mf::merge_nodes(std::hint::black_box(&mut cracked), 1e-12);
                 },
                 BatchSize::LargeInput,
             )

--- a/meficore/benches/neighbours.rs
+++ b/meficore/benches/neighbours.rs
@@ -50,6 +50,7 @@ fn boundaries(c: &mut Criterion) {
     }
 }
 
+#[allow(unused)]
 #[cfg(feature = "rayon")]
 fn par_neighbours(c: &mut Criterion) {
     let mut group = c.benchmark_group("par_neighbours");

--- a/meficore/benches/snap.rs
+++ b/meficore/benches/snap.rs
@@ -1,4 +1,5 @@
 use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 use mefikit::prelude as mf;
 
@@ -19,7 +20,7 @@ fn snap(c: &mut Criterion) {
                 |(m1, m2)| {
                     let mut m1 = m1.clone();
                     let m2_view = m2.view();
-                    std::hint::black_box(mf::snap(&mut m1, m2_view, 1e-12));
+                    mf::snap(black_box(&mut m1), black_box(m2_view), 1e-12);
                 },
                 BatchSize::LargeInput,
             )

--- a/meficore/src/element_traits/element_topo.rs
+++ b/meficore/src/element_traits/element_topo.rs
@@ -1,6 +1,4 @@
 use ndarray::prelude::*;
-#[cfg(feature = "rayon")]
-use rayon::prelude::*;
 
 use crate::mesh::Connectivity;
 use crate::mesh::{Dimension, ElementLike, ElementType};

--- a/meficore/src/element_traits/symmetry.rs
+++ b/meficore/src/element_traits/symmetry.rs
@@ -1,6 +1,7 @@
 use crate::mesh::ElementLike;
 use rustc_hash::FxHashSet as HashSet;
 
+#[allow(unused)]
 pub trait ElementEquality<'a>: ElementLike<'a> {
     fn strict_equality(&self, other: &Self) -> bool {
         if self.connectivity().len() != other.connectivity().len() {

--- a/meficore/src/io/vtk_io.rs
+++ b/meficore/src/io/vtk_io.rs
@@ -134,7 +134,7 @@ pub fn read(path: &Path) -> Result<UMesh, Box<dyn std::error::Error>> {
     let cell_type = piece.cells.types;
 
     // TODO: for efficiency I could preallocate the connectivities vectors
-    for i in 0..cell_type.len() {
+    for (i, _) in cell_type.iter().enumerate() {
         let cell_connectivity =
             extract_connectivity(connectivity.as_slice(), offsets.as_slice(), i);
         mesh.add_element(

--- a/meficore/src/mesh/connectivity.rs
+++ b/meficore/src/mesh/connectivity.rs
@@ -211,7 +211,7 @@ mod tests {
         let conn = arr2(&[[0, 1], [1, 2], [2, 3]]);
         let connectivity = Connectivity::new_regular(conn.into_shared());
         let result = std::panic::catch_unwind(|| {
-            &connectivity[3];
+            let _ = &connectivity[3];
         });
         assert!(result.is_err());
     }

--- a/meficore/src/mesh/element_block.rs
+++ b/meficore/src/mesh/element_block.rs
@@ -149,10 +149,9 @@ impl ElementBlock {
             Some(fams) => Some(fams),
             None => Some(nd::ArcArray1::from(vec![0; conn_len])),
         };
-        let fields = match fields {
-            Some(fds) => fds,
-            None => BTreeMap::new(),
-        };
+
+        let fields = fields.unwrap_or_default();
+
         Self {
             cell_type,
             connectivity: Connectivity::Regular(connectivity),

--- a/meficore/src/mesh/element_ids.rs
+++ b/meficore/src/mesh/element_ids.rs
@@ -67,6 +67,7 @@ impl ElementIds {
         })
     }
 
+    #[allow(clippy::should_implement_trait)]
     pub fn into_iter(self) -> impl Iterator<Item = ElementId> {
         self.0.into_iter().flat_map(|(et, indices)| {
             indices

--- a/meficore/src/mesh/element_ids_set.rs
+++ b/meficore/src/mesh/element_ids_set.rs
@@ -1,6 +1,4 @@
 use itertools::Itertools;
-#[cfg(feature = "rayon")]
-use rayon::prelude::*;
 use rustc_hash::FxHashSet;
 use std::collections::BTreeMap;
 
@@ -98,6 +96,7 @@ impl ElementIdsSet {
             }
         }
     }
+    #[allow(clippy::should_implement_trait)]
     pub fn into_iter(self) -> impl Iterator<Item = ElementId> {
         self.0.into_iter().flat_map(|(et, indices_set)| {
             indices_set
@@ -183,6 +182,6 @@ mod tests {
         set1.intersection(&set2);
 
         assert_eq!(set1.0.get(&ElementType::TRI3).unwrap().len(), 1);
-        assert!(set1.0.get(&ElementType::QUAD4).is_none());
+        assert!(!set1.0.contains_key(&ElementType::QUAD4));
     }
 }

--- a/meficore/src/mesh/umesh.rs
+++ b/meficore/src/mesh/umesh.rs
@@ -560,7 +560,7 @@ impl UMesh {
             match &self.element_blocks[t] {
                 ElementBlockBase {
                     connectivity: ConnectivityBase::Regular(arr),
-                    fields: fields,
+                    fields,
                     ..
                 } => extracted.add_regular_block(
                     *t,

--- a/meficore/src/tools/extrude.rs
+++ b/meficore/src/tools/extrude.rs
@@ -60,6 +60,7 @@ fn extrude_coords_parallel(
 }
 
 /// This allows curvilinear extrusion along a new axis with non parallel planes.
+/// This method is only valid in 3d.
 ///
 /// A new axis is added with coords from along. The x (and potentially y) coords take an offset and
 /// a rotation from the along array. The offset starts at 0., so if along does not starts at [0.,
@@ -79,14 +80,13 @@ fn extrude_coords_curvilinear(
     let new_axis = nd::Array::from_elem((coords.nrows(), 1), z0);
     let coords = nd::concatenate(nd::Axis(1), &[coords, new_axis.view()]).unwrap();
 
-    let origin = along.slice(s![0, ..]).to_owned();
+    // TODO: implement the method for 2d extrusion
     let zero = nd::arr2(&[[0., 0., 0.]]);
     let offsets_vecs = nd::concatenate![
         nd::Axis(0),
         zero,
         &along.slice(s![1.., ..]) - &along.slice(s![..-1, ..]),
     ]; // z starts at 0.0
-    // first offsets_vecs row should be full zeros
 
     // Compute normals
     // 1. Compute vectors

--- a/meficore/src/tools/fieldexpr.rs
+++ b/meficore/src/tools/fieldexpr.rs
@@ -296,6 +296,6 @@ mod test {
         let mut m = me::make_imesh_2d(10);
         m.measure_update("M", None);
         let mes_squared5 = field("M").square() * arr(nd::arr0(5.));
-        let fs5 = m.eval_field(None, mes_squared5);
+        m.eval_field(None, mes_squared5);
     }
 }

--- a/meficore/src/tools/intersect.rs
+++ b/meficore/src/tools/intersect.rs
@@ -7,12 +7,16 @@ use rstar::primitives::{GeomWithData, Line};
 /// A wrapper struct representing a geometric line segment with associated element ID data.
 ///
 /// The segment is defined by a `Line<[f64; 2]>` geometry and an `ElementId` for identification.
+#[allow(unused)]
 struct Segment(GeomWithData<Line<[f64; 2]>, ElementId>);
 
 impl Segment {
+    #[allow(unused)]
     pub fn new(p1: [f64; 2], p2: [f64; 2], eid: ElementId) -> Self {
         Self(GeomWithData::new(Line { from: p1, to: p2 }, eid))
     }
+
+    #[allow(unused)]
     fn from(el: &Element) -> Self {
         let p1: [f64; 2] = *el.coord2_ref(0);
         let p2: [f64; 2] = *el.coord2_ref(1);
@@ -20,9 +24,11 @@ impl Segment {
     }
 }
 
+#[allow(unused)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 struct DirectedEdge(usize, usize);
 
+#[allow(unused)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 struct UndirectedEdge(usize, usize);
 
@@ -44,6 +50,7 @@ impl From<DirectedEdge> for UndirectedEdge {
 //     }
 // }
 
+#[allow(unused)]
 fn point_on_segment(p: [f64; 2], a: [f64; 2], b: [f64; 2], eps: f64) -> bool {
     let cross = ((b[0] - a[0]) * (p[1] - a[1]) - (b[1] - a[1]) * (p[0] - a[0])).abs();
     if cross > eps {
@@ -64,6 +71,7 @@ fn point_on_segment(p: [f64; 2], a: [f64; 2], b: [f64; 2], eps: f64) -> bool {
 /// SEG3).
 ///
 /// The implementation should be completly symmetric for it to be correct.
+#[allow(unused)]
 fn intersect_1d_elems(
     e1: &Element,
     e2: &Element,

--- a/meficore/src/tools/selector/element.rs
+++ b/meficore/src/tools/selector/element.rs
@@ -10,7 +10,7 @@ pub enum ElementSelection {
 }
 
 impl ElementSelection {
-    pub fn select_types<'a>(types: &[ElementType], mut sel: ElementIdsSet) -> ElementIdsSet {
+    pub fn select_types(types: &[ElementType], mut sel: ElementIdsSet) -> ElementIdsSet {
         let sel_types: Vec<_> = sel.keys().collect();
         let types_to_match: FxHashSet<_> = types.iter().collect();
         for k in sel_types {
@@ -20,7 +20,7 @@ impl ElementSelection {
         }
         sel
     }
-    pub fn select_dimensions<'a>(dims: &[Dimension], mut sel: ElementIdsSet) -> ElementIdsSet {
+    pub fn select_dimensions(dims: &[Dimension], mut sel: ElementIdsSet) -> ElementIdsSet {
         let mut key_toremove = Vec::new();
         for k in sel.keys() {
             if !dims.contains(&k.dimension()) {
@@ -32,7 +32,7 @@ impl ElementSelection {
         }
         sel
     }
-    pub fn select_ids<'a>(ids: ElementIds, mut sel: ElementIdsSet) -> ElementIdsSet {
+    pub fn select_ids(ids: ElementIds, mut sel: ElementIdsSet) -> ElementIdsSet {
         let ids: ElementIdsSet = ids.into();
         sel.intersection(&ids);
         sel

--- a/meficore/src/tools/selector/selection.rs
+++ b/meficore/src/tools/selector/selection.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "rayon")]
-use rayon::prelude::*;
-
 use std::ops::{BitAnd, BitOr, BitXor, Not, Sub};
 use std::sync::Arc;
 use std::thread;

--- a/mefipy/src/pyumesh.rs
+++ b/mefipy/src/pyumesh.rs
@@ -1,4 +1,3 @@
-use ndarray::ArrayView2;
 use pyo3::prelude::*;
 use std::{
     collections::BTreeMap,


### PR DESCRIPTION
A small contribution which:
- Set `clippy` warning level to `pedantic` at the workspace cargo manifest level
- Add a `cargo clippy` pre-commit hook to `.pre-commit-config.yaml`
- Fix the `clippy::pedantic` lints the most direct way (not necessarily the best way)

I've notably removed few `#[cfg(feature = "rayon")]` which seemed unused but which might need a double check to ensure I did nothing wrong (crate still compiles with `-F rayon`, though)