### PR TITLE
feat: take &UMeshView instead of UMeshView by value

### DIFF
--- a/crates/mefikit-py/src/pyumesh.rs
+++ b/crates/mefikit-py/src/pyumesh.rs
@@ -190,7 +190,7 @@ impl PyUMesh {
     }
 
     fn measure<'py>(&self, py: Python<'py>) -> BTreeMap<String, Bound<'py, np::PyArray1<f64>>> {
-        mf::measure(self.inner.view(), None)
+        mf::measure(&self.inner.view(), None)
             .iter()
             .map(|(&et, arr)| (etype_to_str(et), np::PyArray1::from_array(py, arr)))
             .collect()
@@ -212,13 +212,13 @@ impl PyUMesh {
     // }
 
     fn crack(&self, cut_mesh: &PyUMesh) -> Self {
-        mf::crack(self.inner.clone(), cut_mesh.inner.view()).into()
+        mf::crack(self.inner.clone(), &cut_mesh.inner.view()).into()
     }
 
     #[pyo3(signature = (reference, eps=1e-12))]
     fn snap(&self, reference: &PyUMesh, eps: f64) -> Self {
         let mut snapped = self.inner.clone();
-        snapped.snap_on(reference.inner.view(), eps);
+        snapped.snap_on(&reference.inner.view(), eps);
         snapped.into()
     }
 
@@ -231,17 +231,17 @@ impl PyUMesh {
 
     fn extrude(&self, along: &Bound<'_, PyAny>) -> PyResult<Self> {
         let along: Vec<f64> = along.extract()?;
-        let new_mesh = mf::extrude(self.inner.view(), &along);
+        let new_mesh = mf::extrude(&self.inner.view(), &along);
         Ok(new_mesh.into())
     }
 
     fn extrude_parallel(&self, along: PyReadonlyArray2<'_, f64>) -> Self {
-        let new_mesh = mf::extrude_parallel(self.inner.view(), along.as_array());
+        let new_mesh = mf::extrude_parallel(&self.inner.view(), along.as_array());
         new_mesh.into()
     }
 
     fn extrude_curv(&self, along: PyReadonlyArray2<'_, f64>) -> Self {
-        let new_mesh = mf::extrude_curv(self.inner.view(), along.as_array());
+        let new_mesh = mf::extrude_curv(&self.inner.view(), along.as_array());
         new_mesh.into()
     }
 

--- a/crates/mefikit/benches/crack.rs
+++ b/crates/mefikit/benches/crack.rs
@@ -17,7 +17,7 @@ fn crack(c: &mut Criterion) {
                     (m1, cut)
                 },
                 |(m1, cut)| {
-                    let cut_view = cut.view();
+                    let cut_view = &cut.view();
                     std::hint::black_box(mf::crack(m1, cut_view));
                 },
                 BatchSize::LargeInput,

--- a/crates/mefikit/benches/measure.rs
+++ b/crates/mefikit/benches/measure.rs
@@ -15,7 +15,7 @@ fn measure2(c: &mut Criterion) {
                         .build()
                 },
                 |mesh| {
-                    let view = mesh.view();
+                    let view = &mesh.view();
                     std::hint::black_box(mf::measure(view, None));
                 },
                 BatchSize::LargeInput,

--- a/crates/mefikit/benches/merge_nodes.rs
+++ b/crates/mefikit/benches/merge_nodes.rs
@@ -14,7 +14,7 @@ fn merge_nodes(c: &mut Criterion) {
                         .add_axis((0..(i + 1)).map(|k| (k as f64) / (i as f64)).collect())
                         .build();
                     let cut = mf::compute_descending(&m1, None, None);
-                    mf::crack(m1, cut.view())
+                    mf::crack(m1, &cut.view())
                 },
                 |mut cracked| {
                     mf::merge_nodes(std::hint::black_box(&mut cracked), 1e-12);

--- a/crates/mefikit/benches/snap.rs
+++ b/crates/mefikit/benches/snap.rs
@@ -19,7 +19,7 @@ fn snap(c: &mut Criterion) {
                 },
                 |(m1, m2)| {
                     let mut m1 = m1.clone();
-                    let m2_view = m2.view();
+                    let m2_view = &m2.view();
                     mf::snap(black_box(&mut m1), black_box(m2_view), 1e-12);
                 },
                 BatchSize::LargeInput,

--- a/crates/mefikit/benches/snap_order.rs
+++ b/crates/mefikit/benches/snap_order.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let mesh2 = mesh1.clone();
             (mesh1, mesh2)
         },
-        |(m1, m2)| mf::snap::snap(m1, m2.view(), 1e-12),
+        |(m1, m2)| mf::snap::snap(m1, &m2.view(), 1e-12),
         10000,
     );
     println!("snapping bench: {benched_snap}");

--- a/crates/mefikit/examples/bubbles.rs
+++ b/crates/mefikit/examples/bubbles.rs
@@ -53,7 +53,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let t1 = now.elapsed().as_secs_f64();
     let (_, inner_bubbles) = volumes.select(sphere_union, false);
     let interface = inner_bubbles.boundaries(None, None);
-    let _cracked = mf::crack(volumes, interface.view());
+    let _cracked = mf::crack(volumes, &interface.view());
     let _bubble_groups = mf::compute_connected_components(&inner_bubbles, None, None, false);
 
     let t_tot = now.elapsed().as_secs_f64();

--- a/crates/mefikit/examples/crack.rs
+++ b/crates/mefikit/examples/crack.rs
@@ -27,7 +27,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Start: building crackedmesh");
     let now = time::Instant::now();
-    let cracked = mf::crack::crack(mesh, partdescending_mesh.view());
+    let cracked = mf::crack::crack(mesh, &partdescending_mesh.view());
     let elapsed = now.elapsed();
     let ttot = elapsed.as_secs_f64();
     mf::write(Path::new("cracked.vtk"), cracked.view())?;

--- a/crates/mefikit/examples/measure.rs
+++ b/crates/mefikit/examples/measure.rs
@@ -12,7 +12,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let n = 100;
     for _ in 0..n {
         let now = time::Instant::now();
-        let _ = mf::measure(mesh.view(), None);
+        let _ = mf::measure(&mesh.view(), None);
         let elapsed = now.elapsed();
         t_tot += elapsed.as_secs_f64();
     }

--- a/crates/mefikit/examples/merge_nodes.rs
+++ b/crates/mefikit/examples/merge_nodes.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let descending_mesh = mf::compute_descending(&mesh, None, None);
     let (_, descending_mesh) = descending_mesh.select(mf::sel::sphere([0.5, 0.5, 0.5], 0.5), false);
 
-    let mut cracked = mf::crack(mesh, descending_mesh.view());
+    let mut cracked = mf::crack(mesh, &descending_mesh.view());
 
     println!("Start: merge_nodes");
     let now = time::Instant::now();

--- a/crates/mefikit/examples/snap.rs
+++ b/crates/mefikit/examples/snap.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Start: snapping");
     let now = time::Instant::now();
-    mesh1.snap_on(mesh2.view(), 1e-12);
+    mesh1.snap_on(&mesh2.view(), 1e-12);
     let elapsed = now.elapsed();
     let ttot = elapsed.as_secs_f64();
     mf::write(Path::new("snapped.vtk"), mesh1.view())?;

--- a/crates/mefikit/src/tools/centroids.rs
+++ b/crates/mefikit/src/tools/centroids.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeMap;
 ///
 /// Returns a map of element types to arrays of measure values.
 pub fn centroids(
-    mesh: UMeshView,
+    mesh: &UMeshView,
     dim: Option<Dimension>,
 ) -> BTreeMap<ElementType, nd::Array2<f64>> {
     let dim = dim.unwrap_or_else(|| mesh.topological_dimension().unwrap());
@@ -61,7 +61,10 @@ pub fn centroids(
 /// Computes the x coord of each element center in the mesh.
 ///
 /// Returns a map of element types to arrays of measure values.
-pub fn x_center(mesh: UMeshView, dim: Option<Dimension>) -> BTreeMap<ElementType, nd::Array2<f64>> {
+pub fn x_center(
+    mesh: &UMeshView,
+    dim: Option<Dimension>,
+) -> BTreeMap<ElementType, nd::Array2<f64>> {
     let dim = dim.unwrap_or_else(|| mesh.topological_dimension().unwrap());
     mesh.par_blocks()
         .filter(|(et, _)| et.dimension() == dim)
@@ -80,7 +83,10 @@ pub fn x_center(mesh: UMeshView, dim: Option<Dimension>) -> BTreeMap<ElementType
 /// Computes the y coord of each element center in the mesh.
 ///
 /// Returns a map of element types to arrays of measure values.
-pub fn y_center(mesh: UMeshView, dim: Option<Dimension>) -> BTreeMap<ElementType, nd::Array2<f64>> {
+pub fn y_center(
+    mesh: &UMeshView,
+    dim: Option<Dimension>,
+) -> BTreeMap<ElementType, nd::Array2<f64>> {
     let dim = dim.unwrap_or_else(|| mesh.topological_dimension().unwrap());
     mesh.par_blocks()
         .filter(|(et, _)| et.dimension() == dim)
@@ -99,7 +105,10 @@ pub fn y_center(mesh: UMeshView, dim: Option<Dimension>) -> BTreeMap<ElementType
 /// Computes the z coord of each element center in the mesh.
 ///
 /// Returns a map of element types to arrays of measure values.
-pub fn z_center(mesh: UMeshView, dim: Option<Dimension>) -> BTreeMap<ElementType, nd::Array2<f64>> {
+pub fn z_center(
+    mesh: &UMeshView,
+    dim: Option<Dimension>,
+) -> BTreeMap<ElementType, nd::Array2<f64>> {
     let dim = dim.unwrap_or_else(|| mesh.topological_dimension().unwrap());
     mesh.par_blocks()
         .filter(|(et, _)| et.dimension() == dim)

--- a/crates/mefikit/src/tools/connected_components.rs
+++ b/crates/mefikit/src/tools/connected_components.rs
@@ -54,7 +54,7 @@ mod tests {
         let sphere3 = sel::sphere([0.5, 0.2, 0.2], 0.15);
         let (_, spheres) = mesh.select(sphere1 | sphere2 | sphere3, false);
         let bounds = spheres.boundaries(None, None);
-        let cracked = mf::crack(mesh, bounds.view());
+        let cracked = mf::crack(mesh, &bounds.view());
         let components = compute_connected_components(&cracked, None, None, false);
         assert_eq!(components.len(), 3);
     }

--- a/crates/mefikit/src/tools/crack.rs
+++ b/crates/mefikit/src/tools/crack.rs
@@ -16,7 +16,7 @@ use crate::tools::selector::{MeshSelect, sel};
 /// Gets the ids of elements from partmesh which are in mesh_ref.
 ///
 /// Supposes that the coordinates array is the same.
-fn find_equals(mesh_ref: UMeshView, partmesh: UMeshView) -> Vec<Option<ElementId>> {
+fn find_equals(mesh_ref: &UMeshView, partmesh: &UMeshView) -> Vec<Option<ElementId>> {
     let dims: FxHashSet<Dimension> = partmesh.element_types().map(|&et| et.dimension()).collect();
     let mut hash_to_ref: FxHashMap<SortedVecKey, ElementId> = HashMap::default();
     for dim in dims {
@@ -53,7 +53,7 @@ fn build_subgraph(
     subgraph
 }
 
-fn compute_node_to_elems(mesh: UMeshView) -> FxHashMap<usize, ElementIds> {
+fn compute_node_to_elems(mesh: &UMeshView) -> FxHashMap<usize, ElementIds> {
     let mut node_to_elem: FxHashMap<usize, ElementIds> =
         FxHashMap::with_capacity_and_hasher(mesh.used_nodes().len(), FxBuildHasher);
     for e in mesh.elements() {
@@ -68,14 +68,14 @@ fn compute_node_to_elems(mesh: UMeshView) -> FxHashMap<usize, ElementIds> {
     node_to_elem
 }
 
-pub fn crack(mut mesh: UMesh, cut: UMeshView) -> UMesh {
+pub fn crack(mut mesh: UMesh, cut: &UMeshView) -> UMesh {
     // First extract the vicinity of the cut
     let nodes = cut.used_nodes();
     let index = mesh.select_ids(sel::nids(nodes.clone(), false));
     let mut near_mesh = mesh.extract(&index, true);
     let (descending_mesh, f2c) = compute_sub_to_elem(&near_mesh, None, None);
     // Throws if some element in cut is not in descending_mesh
-    let cut_ids = find_equals(descending_mesh.view(), cut.view());
+    let cut_ids = find_equals(&descending_mesh.view(), &cut.view());
     let cut_c2c: Vec<[ElementId; 2]> = cut_ids
         .into_iter()
         .map(|x| x.expect("cut elements should be found in mesh descending_mesh."))
@@ -93,7 +93,7 @@ pub fn crack(mut mesh: UMesh, cut: UMeshView) -> UMesh {
     // let mut n2o_nodes: FxHashMap<usize, usize> =
     //     FxHashMap::with_capacity_and_hasher(2 * nodes.len(), FxBuildHasher);
 
-    let node_to_elem: FxHashMap<usize, ElementIds> = compute_node_to_elems(near_mesh.view());
+    let node_to_elem: FxHashMap<usize, ElementIds> = compute_node_to_elems(&near_mesh.view());
 
     for n in nodes {
         // 1. Build graph of cells touching node n

--- a/crates/mefikit/src/tools/extrude.rs
+++ b/crates/mefikit/src/tools/extrude.rs
@@ -236,7 +236,7 @@ fn cross(a: ArrayView1<f64>, b: ArrayView1<f64>) -> Array1<f64> {
 //     nd::concatenate(nd::Axis(0), &new_coords_views).unwrap()
 // }
 
-fn extrude_dup_connectivity(mesh: UMeshView, et: ElementType, n: usize) -> nd::Array2<usize> {
+fn extrude_dup_connectivity(mesh: &UMeshView, et: ElementType, n: usize) -> nd::Array2<usize> {
     let old_connectivity = mesh.regular_connectivity(et).unwrap();
     let n_nodes = mesh.coords().nrows();
     let old_elem_size = old_connectivity.ncols();
@@ -260,7 +260,7 @@ fn extrude_dup_connectivity(mesh: UMeshView, et: ElementType, n: usize) -> nd::A
     new_connectivity
 }
 
-fn extrude_inv_connectivity(mesh: UMeshView, et: ElementType, n: usize) -> nd::Array2<usize> {
+fn extrude_inv_connectivity(mesh: &UMeshView, et: ElementType, n: usize) -> nd::Array2<usize> {
     let old_connectivity = mesh.regular_connectivity(et).unwrap();
     let n_nodes = mesh.coords().nrows();
     let old_elem_size = old_connectivity.ncols();
@@ -285,7 +285,7 @@ fn extrude_inv_connectivity(mesh: UMeshView, et: ElementType, n: usize) -> nd::A
 }
 
 fn extrude_connectivity(
-    mesh: UMeshView,
+    mesh: &UMeshView,
     n: usize,
     new_coords: ndarray::ArrayBase<ndarray::OwnedRepr<f64>, ndarray::Dim<[usize; 2]>, f64>,
 ) -> UMesh {
@@ -296,17 +296,17 @@ fn extrude_connectivity(
         match et {
             VERTEX => extruded_mesh.add_regular_block(
                 SEG2,
-                extrude_dup_connectivity(mesh.view(), et, n).into_shared(),
+                extrude_dup_connectivity(&mesh.view(), et, n).into_shared(),
                 None,
             ),
             SEG2 => extruded_mesh.add_regular_block(
                 QUAD4,
-                extrude_inv_connectivity(mesh.view(), et, n).into_shared(),
+                extrude_inv_connectivity(&mesh.view(), et, n).into_shared(),
                 None,
             ),
             QUAD4 => extruded_mesh.add_regular_block(
                 HEX8,
-                extrude_dup_connectivity(mesh.view(), et, n).into_shared(),
+                extrude_dup_connectivity(&mesh.view(), et, n).into_shared(),
                 None,
             ),
             _ => todo!("Extrusion of {et:?} is not implemented yet"),
@@ -315,7 +315,7 @@ fn extrude_connectivity(
     extruded_mesh
 }
 
-pub fn extrude(mesh: UMeshView, along: &[f64]) -> UMesh {
+pub fn extrude(mesh: &UMeshView, along: &[f64]) -> UMesh {
     if along.is_empty() {
         return mesh.to_shared();
     }
@@ -328,7 +328,7 @@ pub fn extrude(mesh: UMeshView, along: &[f64]) -> UMesh {
     extrude_connectivity(mesh, along.len() - 1, new_coords)
 }
 
-pub fn extrude_parallel(mesh: UMeshView, along: nd::ArrayView2<'_, f64>) -> UMesh {
+pub fn extrude_parallel(mesh: &UMeshView, along: nd::ArrayView2<'_, f64>) -> UMesh {
     if along.is_empty() {
         return mesh.to_shared();
     }
@@ -341,7 +341,7 @@ pub fn extrude_parallel(mesh: UMeshView, along: nd::ArrayView2<'_, f64>) -> UMes
     extrude_connectivity(mesh, along.nrows() - 1, new_coords)
 }
 
-pub fn extrude_curv(mesh: UMeshView, along: nd::ArrayView2<'_, f64>) -> UMesh {
+pub fn extrude_curv(mesh: &UMeshView, along: nd::ArrayView2<'_, f64>) -> UMesh {
     if along.is_empty() {
         return mesh.to_shared();
     }
@@ -364,29 +364,29 @@ pub trait Extrudable {
 
 impl Extrudable for UMeshView<'_> {
     fn extrude(&self, along: &[f64]) -> UMesh {
-        extrude(self.clone(), along)
+        extrude(self, along)
     }
 
     fn extrude_parallel(&self, along: ndarray::ArrayView2<'_, f64>) -> UMesh {
-        extrude_parallel(self.clone(), along)
+        extrude_parallel(self, along)
     }
 
     fn extrude_curv(&self, along: ndarray::ArrayView2<'_, f64>) -> UMesh {
-        extrude_curv(self.clone(), along)
+        extrude_curv(self, along)
     }
 }
 
 impl Extrudable for UMesh {
     fn extrude(&self, along: &[f64]) -> UMesh {
-        extrude(self.view(), along)
+        extrude(&self.view(), along)
     }
 
     fn extrude_parallel(&self, along: ndarray::ArrayView2<'_, f64>) -> UMesh {
-        extrude_parallel(self.view(), along)
+        extrude_parallel(&self.view(), along)
     }
 
     fn extrude_curv(&self, along: ndarray::ArrayView2<'_, f64>) -> UMesh {
-        extrude_curv(self.view(), along)
+        extrude_curv(&self.view(), along)
     }
 }
 

--- a/crates/mefikit/src/tools/fieldexpr.rs
+++ b/crates/mefikit/src/tools/fieldexpr.rs
@@ -282,14 +282,14 @@ impl Evaluable for FieldExpr {
                 }
             }
             FieldExpr::Measure => FieldOwnedD::new(
-                measure(mesh.clone(), None)
+                measure(mesh, None)
                     .into_iter()
                     .map(|(k, v)| (k, v.into_dyn()))
                     .collect(),
             )
             .into(),
             FieldExpr::Centroids => FieldOwnedD::new(
-                centroids(mesh.clone(), None)
+                centroids(mesh, None)
                     .into_iter()
                     .map(|(k, v)| (k, v.into_dyn()))
                     .collect(),

--- a/crates/mefikit/src/tools/measure.rs
+++ b/crates/mefikit/src/tools/measure.rs
@@ -16,7 +16,7 @@ use std::collections::BTreeMap;
 /// Computes the geometric measure of each element in the mesh.
 ///
 /// Returns a map of element types to arrays of measure values.
-pub fn measure(mesh: UMeshView, dim: Option<Dimension>) -> BTreeMap<ElementType, nd::Array1<f64>> {
+pub fn measure(mesh: &UMeshView, dim: Option<Dimension>) -> BTreeMap<ElementType, nd::Array1<f64>> {
     let dim = dim.unwrap_or_else(|| mesh.topological_dimension().unwrap());
     mesh
         .par_blocks()
@@ -58,10 +58,10 @@ pub trait Measurable {
 
 impl Measurable for UMesh {
     fn measure(&self, dim: Option<Dimension>) -> FieldOwned<ndarray::Ix1> {
-        FieldOwned::new(measure(self.view(), dim))
+        FieldOwned::new(measure(&self.view(), dim))
     }
     fn measure_update(&mut self, name: &str, dim: Option<Dimension>) {
-        let field = FieldOwned::new(measure(self.view(), dim));
+        let field = FieldOwned::new(measure(&self.view(), dim));
         self.update_field(name, field.into_shared().into_dyn(), dim);
     }
 }
@@ -76,7 +76,7 @@ mod tests {
     #[test]
     fn test_umesh_measure() {
         let mesh = me::make_mesh_2d_quad();
-        let measures = measure(mesh.view(), None);
+        let measures = measure(&mesh.view(), None);
         assert_eq!(measures.len(), 1);
         assert!(measures.contains_key(&ElementType::QUAD4));
         let measure_values = measures.get(&ElementType::QUAD4).unwrap();
@@ -87,7 +87,7 @@ mod tests {
     #[test]
     fn test_measure_seg2() {
         let mesh = me::make_mesh_3d_seg2();
-        let measures = measure(mesh.view(), Some(crate::mesh::Dimension::D1));
+        let measures = measure(&mesh.view(), Some(crate::mesh::Dimension::D1));
         assert!(measures.contains_key(&ElementType::SEG2));
         let measure_values = measures.get(&ElementType::SEG2).unwrap();
         assert_eq!(measure_values.len(), 2);

--- a/crates/mefikit/src/tools/overlay.rs
+++ b/crates/mefikit/src/tools/overlay.rs
@@ -48,7 +48,7 @@ use crate::tools::{Descendable, spatial_index::SpatiallyIndexable};
 /// to resolve intersection node ids.
 fn merge_on_reference_coords(subject: UMesh, reference: UMeshView) -> UMesh {
     // reference node id -> coincident subject node ids
-    let ref_to_subject_nodes = duplicates_from(subject.view(), reference.clone(), 1e-12);
+    let ref_to_subject_nodes = duplicates_from(&subject.view(), &reference.clone(), 1e-12);
     let shift = reference.coords().nrows();
     // In the merged mesh, subject node `n` lives at `n + shift`. When it coincides with reference
     // node `r`, re-point it to `r` so both meshes share the node id.

--- a/crates/mefikit/src/tools/snap.rs
+++ b/crates/mefikit/src/tools/snap.rs
@@ -5,7 +5,7 @@ use nalgebra as na;
 use rstar::{RTree, primitives::GeomWithData};
 use rustc_hash::FxHashMap;
 
-fn snap_dim_n<const T: usize>(subject: &mut UMesh, reference: UMeshView, eps: f64) {
+fn snap_dim_n<const T: usize>(subject: &mut UMesh, reference: &UMeshView, eps: f64) {
     let ref_points: Vec<[f64; T]> = reference
         .used_nodes()
         .into_iter()
@@ -49,8 +49,8 @@ fn snap_dim_n<const T: usize>(subject: &mut UMesh, reference: UMeshView, eps: f6
 }
 
 fn duplicates_from_dim_n<const T: usize>(
-    subject: UMeshView,
-    reference: UMeshView,
+    subject: &UMeshView,
+    reference: &UMeshView,
     eps: f64,
 ) -> FxHashMap<usize, Vec<usize>> {
     let mut res: FxHashMap<usize, Vec<usize>> = FxHashMap::default();
@@ -103,8 +103,8 @@ fn duplicates_from_dim_n<const T: usize>(
 
 /// Find duplicates coords of subject mesh onto used nodes of reference.
 pub fn duplicates_from(
-    subject: UMeshView,
-    reference: UMeshView,
+    subject: &UMeshView,
+    reference: &UMeshView,
     eps: f64,
 ) -> FxHashMap<usize, Vec<usize>> {
     match subject.coords().ncols() {
@@ -119,7 +119,7 @@ pub fn duplicates_from(
 ///
 /// Be careful, the method could produce degenerated elements if eps is not lower than half the
 /// smallest distance between two points from the same element.
-pub fn snap(subject: &mut UMesh, reference: UMeshView, eps: f64) {
+pub fn snap(subject: &mut UMesh, reference: &UMeshView, eps: f64) {
     match subject.coords().ncols() {
         // 1 => snap_dim_n::<1>(subject, reference, eps),
         2 => snap_dim_n::<2>(subject, reference, eps),
@@ -128,7 +128,7 @@ pub fn snap(subject: &mut UMesh, reference: UMeshView, eps: f64) {
     }
 }
 
-fn duplicates_dim_n<const T: usize>(mesh: UMeshView, eps: f64) -> IndirectIndexOwned<usize> {
+fn duplicates_dim_n<const T: usize>(mesh: &UMeshView, eps: f64) -> IndirectIndexOwned<usize> {
     let used_nodes = mesh.used_nodes();
     let points: Vec<GeomWithData<[f64; T], usize>> = used_nodes
         .iter()
@@ -159,7 +159,7 @@ fn duplicates_dim_n<const T: usize>(mesh: UMeshView, eps: f64) -> IndirectIndexO
     res
 }
 
-pub fn duplicates(mesh: UMeshView, eps: f64) -> IndirectIndexOwned<usize> {
+pub fn duplicates(mesh: &UMeshView, eps: f64) -> IndirectIndexOwned<usize> {
     match mesh.coords().ncols() {
         1 => duplicates_dim_n::<1>(mesh, eps),
         2 => duplicates_dim_n::<2>(mesh, eps),
@@ -180,7 +180,7 @@ fn find_group(n: &usize, nodes: &[usize], groups: &[usize]) -> Option<usize> {
 /// Be careful, this method can produce degenerated elements if used with an epsilon greater than
 /// the distance between two nodes of the same element.
 pub fn merge_nodes(mesh: &mut UMesh, eps: f64) {
-    let dups = duplicates(mesh.view(), eps);
+    let dups = duplicates(&mesh.view(), eps);
     let sorted_nodes_dup: Vec<(usize, usize)> = dups
         .iter()
         .enumerate()
@@ -207,7 +207,7 @@ pub fn merge_nodes(mesh: &mut UMesh, eps: f64) {
 
 pub trait NodeDuplicates {
     fn merge_nodes(&mut self, eps: f64);
-    fn snap_on(&mut self, other: UMeshView, eps: f64);
+    fn snap_on(&mut self, other: &UMeshView, eps: f64);
 }
 
 impl NodeDuplicates for UMesh {
@@ -215,7 +215,7 @@ impl NodeDuplicates for UMesh {
         merge_nodes(self, eps)
     }
 
-    fn snap_on(&mut self, other: UMeshView, eps: f64) {
+    fn snap_on(&mut self, other: &UMeshView, eps: f64) {
         snap(self, other, eps);
     }
 }
@@ -242,7 +242,7 @@ mod tests {
         let mut reference = UMesh::new(reference_coords.into());
         reference.add_regular_block(ElementType::SEG2, nd::arr2(&[[0, 1]]).to_shared(), None);
 
-        snap(&mut subject, reference.view(), 0.02);
+        snap(&mut subject, &reference.view(), 0.02);
         assert!((subject.coords()[[1, 0]] - 1.0).abs() < 1e-6);
     }
 
@@ -276,7 +276,7 @@ mod tests {
             None,
         );
 
-        let dups = duplicates(mesh.view(), 0.01);
+        let dups = duplicates(&mesh.view(), 0.01);
         // Should find at least one duplicate (nodes 0 and 1)
         assert!(dups.len() > 0);
     }

--- a/crates/mefikit/tests/integration_tests.rs
+++ b/crates/mefikit/tests/integration_tests.rs
@@ -622,7 +622,7 @@ mod geometric_operations {
     #[test]
     fn measure_quad_area() {
         let mesh = make_mesh_2d_quad();
-        let measures = measure(mesh.view(), None);
+        let measures = measure(&mesh.view(), None);
         let quad_measures = measures.get(&ElementType::QUAD4).unwrap();
         assert_abs_diff_eq!(quad_measures[0], 1.0, epsilon = 1e-10);
     }
@@ -632,7 +632,7 @@ mod geometric_operations {
         // Create a mesh with only regular elements (QUAD4) for measure
         let mut mesh = make_mesh_2d_quad();
         mesh.add_element(ElementType::QUAD4, &[0, 1, 3, 2], None, None);
-        let measures = measure(mesh.view(), None);
+        let measures = measure(&mesh.view(), None);
         let quad_measures = measures.get(&ElementType::QUAD4).unwrap();
         let total: f64 = quad_measures.iter().sum();
         assert!(total > 0.0);
@@ -659,7 +659,7 @@ mod snap_operations {
         let mut reference = UMesh::new(reference_coords.clone().into());
         reference.add_regular_block(ElementType::SEG2, nd::arr2(&[[0, 1]]).to_shared(), None);
 
-        snap(&mut subject, reference.view(), 0.02);
+        snap(&mut subject, &reference.view(), 0.02);
         assert_abs_diff_eq!(subject.coords()[[1, 0]], 1.0, epsilon = 1e-6);
     }
 }


### PR DESCRIPTION
- In almost all cases there is no need to own the UMeshView, so it must be passed by ref